### PR TITLE
fix compile problems

### DIFF
--- a/src/ooxml/java/org/apache/poi/xslf/usermodel/XSLFRelation.java
+++ b/src/ooxml/java/org/apache/poi/xslf/usermodel/XSLFRelation.java
@@ -19,246 +19,248 @@ package org.apache.poi.xslf.usermodel;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.poi.POIXMLDocument;
 import org.apache.poi.POIXMLDocumentPart;
 import org.apache.poi.POIXMLRelation;
 import org.apache.poi.sl.usermodel.PictureData.PictureType;
 import org.apache.poi.util.Beta;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 @Beta
 public class XSLFRelation extends POIXMLRelation {
-    
+
     /**
      * A map to lookup POIXMLRelation by its relation type
      */
     private static final Map<String, XSLFRelation> _table = new HashMap<>();
-    
+
     public static final XSLFRelation MAIN = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation MACRO = new XSLFRelation(
             "application/vnd.ms-powerpoint.slideshow.macroEnabled.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation MACRO_TEMPLATE = new XSLFRelation(
             "application/vnd.ms-powerpoint.template.macroEnabled.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation PRESENTATIONML = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.slideshow.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation PRESENTATIONML_TEMPLATE = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.template.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation PRESENTATION_MACRO = new XSLFRelation(
             "application/vnd.ms-powerpoint.presentation.macroEnabled.main+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation THEME_MANAGER = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.themeManager+xml",
             null, null, null
-            );
-    
+    );
+
     public static final XSLFRelation NOTES = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml",
-            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide", 
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide",
             "/ppt/notesSlides/notesSlide#.xml",
             XSLFNotes.class
-            );
-    
+    );
+
     public static final XSLFRelation SLIDE = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
-            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide", 
-            "/ppt/slides/slide#.xml", 
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+            "/ppt/slides/slide#.xml",
             XSLFSlide.class
-            );
-    
+    );
+
     public static final XSLFRelation SLIDE_LAYOUT = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
-            "/ppt/slideLayouts/slideLayout#.xml", 
+            "/ppt/slideLayouts/slideLayout#.xml",
             XSLFSlideLayout.class
-            );
-    
+    );
+
     public static final XSLFRelation SLIDE_MASTER = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster",
             "/ppt/slideMasters/slideMaster#.xml",
             XSLFSlideMaster.class
-            );
-    
+    );
+
     public static final XSLFRelation NOTES_MASTER = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster",
             "/ppt/notesMasters/notesMaster#.xml",
             XSLFNotesMaster.class
-            );
-    
+    );
+
     public static final XSLFRelation COMMENTS = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.comments+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments",
             "/ppt/comments/comment#.xml",
             XSLFComments.class
-            );
-    
+    );
+
     public static final XSLFRelation COMMENT_AUTHORS = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.commentAuthors+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/commentAuthors",
             "/ppt/commentAuthors.xml",
             XSLFCommentAuthors.class
-            );
-    
+    );
+
     public static final XSLFRelation HYPERLINK = new XSLFRelation(
             null,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
             null,
             null
-            );
-    
+    );
+
     public static final XSLFRelation THEME = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.theme+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme",
-            "/ppt/theme/theme#.xml", 
+            "/ppt/theme/theme#.xml",
             XSLFTheme.class
-            );
-    
+    );
+
     public static final XSLFRelation VML_DRAWING = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.vmlDrawing",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing",
-            "/ppt/drawings/vmlDrawing#.vml", 
+            "/ppt/drawings/vmlDrawing#.vml",
             null
-            );
-    
+    );
+
     public static final XSLFRelation WORKBOOK_RELATIONSHIP = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             POIXMLDocument.PACK_OBJECT_REL_TYPE,
             "/ppt/embeddings/Microsoft_Excel_Worksheet#.xlsx",
             XSSFWorkbook.class
     );
-    
+
     public static final XSLFRelation CHART = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.drawingml.chart+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",
             "/ppt/charts/chart#.xml",
             XSLFChart.class
-            );
-    
+    );
+
     public static final XSLFRelation IMAGE_EMF = new XSLFRelation(
             PictureType.EMF.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.emf",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_WMF = new XSLFRelation(
             PictureType.WMF.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.wmf",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_PICT = new XSLFRelation(
             PictureType.PICT.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.pict",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_JPEG = new XSLFRelation(
             PictureType.JPEG.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.jpeg",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_PNG = new XSLFRelation(
             PictureType.PNG.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.png",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_DIB = new XSLFRelation(
             PictureType.DIB.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.dib",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_GIF = new XSLFRelation(
             PictureType.GIF.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.gif",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_TIFF = new XSLFRelation(
             PictureType.TIFF.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.tiff",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_EPS = new XSLFRelation(
             PictureType.EPS.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.eps",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_BMP = new XSLFRelation(
             PictureType.BMP.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.bmp",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_WPG = new XSLFRelation(
             PictureType.WPG.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.wpg",
             XSLFPictureData.class
-            );
+    );
     public static final XSLFRelation IMAGE_WDP = new XSLFRelation(
             PictureType.WDP.contentType,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             "/ppt/media/image#.wdp",
             XSLFPictureData.class
-            );
-    
+    );
+
     public static final XSLFRelation IMAGES = new XSLFRelation(
             null,
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
             null,
             XSLFPictureData.class
-            );
-    
+    );
+
     public static final XSLFRelation TABLE_STYLES = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles",
             "/ppt/tableStyles.xml",
             XSLFTableStyles.class
-            );
-    
+    );
+
     public static final XSLFRelation OLE_OBJECT = new XSLFRelation(
             "application/vnd.openxmlformats-officedocument.oleObject",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/oleObject",
-            "/ppt/embeddings/oleObject#.bin", 
+            "/ppt/embeddings/oleObject#.bin",
             XSLFObjectData.class
-            );
-    
-    
+    );
+
+
     private XSLFRelation(String type, String rel, String defaultName, Class<? extends POIXMLDocumentPart> cls) {
         super(type, rel, defaultName, cls);
         _table.put(rel, this);
     }
-    
+
     /**
      * Get POIXMLRelation by relation type
      *
      * @param rel relation type, for example,
-     *    <code>http://schemas.openxmlformats.org/officeDocument/2006/relationships/image</code>
+     *            <code>http://schemas.openxmlformats.org/officeDocument/2006/relationships/image</code>
      * @return registered POIXMLRelation or null if not found
      */
-    public static XSLFRelation getInstance(String rel){
+    public static XSLFRelation getInstance(String rel) {
         return _table.get(rel);
     }
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFChart.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFChart.java
@@ -20,6 +20,7 @@ package org.apache.poi.xwpf.usermodel;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.xddf.usermodel.chart.XDDFBarChartData;
 import org.apache.poi.xddf.usermodel.chart.XDDFChartData;
 import org.apache.poi.xwpf.XWPFTestDataSamples;


### PR DESCRIPTION
Could you use `ant clean test` to check that your changes build and the tests pass?
This change just gets your changes to compile. There is a broken test still.
To make your change in XSLFRelation work, it looks like XSSFWorkbook needs a new constructor that takes a org.apache.poi.openxml4j.opc.PackagePart input.

```
    <error message="java.lang.NoSuchMethodException: org.apache.poi.xssf.usermodel.XSSFWorkbook.&lt;init&gt;(org.apache.poi.openxml4j.opc.PackagePart)" type="org.apache.poi.POIXMLException">org.apache.poi.POIXMLException: java.lang.NoSuchMethodException: org.apache.poi.xssf.usermodel.XSSFWorkbook.&lt;init&gt;(org.apache.poi.openxml4j.opc.PackagePart)
        at org.apache.poi.POIXMLFactory.createDocumentPart(POIXMLFactory.java:63)
        at org.apache.poi.POIXMLDocumentPart.read(POIXMLDocumentPart.java:668)
        at org.apache.poi.POIXMLDocument.load(POIXMLDocument.java:164)
        at org.apache.poi.xwpf.usermodel.XWPFDocument.&lt;init&gt;(XWPFDocument.java:141)
        at org.apache.poi.TestEmbeded.testWord(TestEmbeded.java:46)
Caused by: java.lang.NoSuchMethodException: org.apache.poi.xssf.usermodel.XSSFWorkbook.&lt;init&gt;(org.apache.poi.openxml4j.opc.PackagePart)
        at java.lang.Class.getConstructor0(Class.java:3082)
        at java.lang.Class.getDeclaredConstructor(Class.java:2178)
        at org.apache.poi.xwpf.usermodel.XWPFFactory.createDocumentPart(XWPFFactory.java:56)
        at org.apache.poi.POIXMLFactory.createDocumentPart(POIXMLFactory.java:60)
</error>
```